### PR TITLE
Fixes #2

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.16;
+pragma solidity 0.6.0;
 
 contract Migrations {
   address public owner;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^3.3.0",
-    "solc": "^0.5.12"
+    "solc": "^0.6.0"
   }
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -6,16 +6,16 @@ module.exports = {
     development: {
       host: 'localhost',
       port: 8545,
-      network_id: '*',
+      network_id: '*'
+    },
+  },
   compilers: {
     solc: { 
-      version: "^0.5.16",
+      version: "0.6.0",
       optimizer: {
         enabled: true,
         runs: 200
       }
     }
   }
-}
-}
 }


### PR DESCRIPTION
### Solidity 0.6 breaking changes

A contract receiving Ether must have at least one of the functions below
- `receive() external payable`
- `fallback() external payable`

`receive()` is called if `msg.data` is empty, otherwise `fallback()` is called.

```solidity
/*
    Which function is called, fallback() or receive()?

           send Ether
               |
         msg.data is empty?
              / \
            yes  no
            /     \
receive() exists?  fallback()
         /   \
        yes   no
        /      \
    receive()   fallback()
*/
```

#### TLDR: `function() external payable` is now splitted into `receive()` and `fallback()`

---

### Destructible is no longer part of OpenZeppelin's contracts

> Self-destructable contracts are open to being _accidentally killed_ and should be used with tons of care because it's not always safe to use, so it shouldn't be as simple as inheriting a contract.

[More in PR](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1254)