### PR TITLE
Fixes #7

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.0;
+pragma solidity ^0.6.0;
 
 contract Migrations {
   address public owner;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   compilers: {
     solc: { 
-      version: "0.6.0",
+      version: "0.6.2",
       optimizer: {
         enabled: true,
         runs: 200


### PR DESCRIPTION
Added withdraw functionality for ERC20 and ERC721 tokens, but they are still need to be called somewhere inside `tryExecuteSwitch` function, because right now anyone can be a receiver.

Also, logic of creating switches now needs to be updated in order to support adding tokens and collectibles. And for those purposes I added two mappings to track info about them
```solidity
mapping(address => uint) tokens; // erc20 token address => amount locked
mapping(address => uint[]) collectibles; // erc721 address => array of tokenIds locked
```