### PR TITLE
Fixes #25

### DIFF
--- a/contracts/TimeBasedSwitch.sol
+++ b/contracts/TimeBasedSwitch.sol
@@ -167,19 +167,26 @@ contract TimeBasedSwitch is ReentrancyGuard {
         ERC721(_tokenAddress).approve(address(this), _tokenId);
     }
 
-    /// @notice Function that tries to fetch unlock time for an account 
+    /// @notice Function that returns Switch struct of given _switchOwner address 
     /// @dev This function is allowed only for executors, befitors or switch creator 
-    /// @param account The account mapped to the switch
-    /// @return Returns unlock block for the switch
-    function getUnlockTime(address account)
-    onlyValid(account)
-    onlyAllowed(account)
+    /// @param _switchOwner The account mapped to the switch
+    /// @return Returns Switch struct
+    function getSwitchInfo(address _switchOwner)
+    onlyValid(_switchOwner)
+    onlyAllowed(_switchOwner)
     public
     view
     returns
-    (uint)
+    (uint, uint, address, address, bool)
     {
-      return (users[account].unlockTimestamp);
+      Switch memory _switch = users[_switchOwner];
+      return (
+        _switch.amount,
+        _switch.unlockTimestamp,
+        _switch.executor,
+        _switch.benefitor,
+        _switch.isValid
+      );
     }
 
     /// @notice Function that tries to terminate switch before the unlock block  


### PR DESCRIPTION
This isn't the final version of `getSwitchInfo` function in my opinion, because we still need to refactor `Switch` struct to support multiple executors, remove `cooldown` parameter, etc.

But it is the current version. Also, I wasn't able to write something like this
```solidity
function getSwitchInfo(address _switchOwner)
    onlyValid(_switchOwner)
    onlyAllowed(_switchOwner)
    public
    view
    returns
    (Switch memory)
    {
      return users[_switchOwner];
    }
```
since there are mappings inside a `Switch` struct and compiler throws error.

Once we have final version of `Switch` struct I can come back to this function and refactor it